### PR TITLE
Fix/phpwrap dispatch typo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chrisroberts.code@gmail.com'
 license          'Apache 2.0'
 description      'Provides SimpleCGI for NGINX'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 
 %w{ debian ubuntu redhat centos fedora scientific amazon oracle }.each do |os|
   supports os

--- a/templates/default/upstart-phpwrap_dispatcher.erb
+++ b/templates/default/upstart-phpwrap_dispatcher.erb
@@ -13,7 +13,7 @@ pre-start script
   chown <%= @nginx_user %>:<%= @nginx_group %> <%= @dispatch_dir %>
 end script
 
-exec /usr/bin/spawn-fcgi -s <%= File.join(@dispatch_dir, 'phpwrap_dispatch.sock') %> \
+exec /usr/bin/spawn-fcgi -s <%= File.join(@dispatch_dir, 'phpwrap-dispatch.sock') %> \
   -P <%= File.join(@dispatch_dir, 'phpwrap_dispatcher.pid') %> \
   -C <%= @dispatch_procs.to_i %> -u <%= @nginx_user %> \
   -g <%= @nginx_group %> -f <%= @php_cgi_bin %> -n


### PR DESCRIPTION
When enabling PHP, this cookbook uses hyphen in nginx configuration, i.e.:
    fastcgi_pass  unix:/var/run/nginx/phpwrap-dispatch.sock;

So subsequently, hyphen must be used when spawning the FCGI socket.
